### PR TITLE
Update munkipromote to enable easy use on non-OSX systems.

### DIFF
--- a/munkipromote
+++ b/munkipromote
@@ -33,8 +33,7 @@ def main():
         sys.exit(1)
     # Read Munki Repo location
     munki_repo = conf_parser.get('main', 'REPO')
-    # Append /pkgsinfo as we only need to go through these files
-    munki_repo = '{0:}/pkgsinfo'.format(munki_repo)
+    pkgsinfo = '{0:}/pkgsinfo'.format(munki_repo)
     # Parse Configuration file for different catalogs and
     # their applications to promote.
     for promotion_group in conf_parser.sections():
@@ -57,9 +56,15 @@ def main():
             config_options[3] = [conf_parser.get(promotion_group,
                                                  'promote_to')]
             # Perform promotion of desired applications
-            promote_apps(munki_repo, promotion_group, config_options)
+            promote_apps(pkgsinfo, promotion_group, config_options)
         else:
             continue
+    if conf_parser.has_option('main', 'MAKECATALOGS'):
+        makecatalogspath = conf_parser.get('main', 'MAKECATALOGS')
+    else:
+        print("Using default value for MAKECATALOGS")
+        makecatalogspath = '/usr/local/munki/makecatalogs'
+    makecatalogs(makecatalogspath, munki_repo)
 
 
 def promote_apps(repo, group, config_options):
@@ -130,7 +135,7 @@ def promote_apps(repo, group, config_options):
             print('{0:{space}}{1:}'.format(name, version, space=space))
         print()
 
-def makecatalogs():
+def makecatalogs(makecatalogspath, munki_repo):
     '''Performs Munki's makecatalogs
     functiong after all promotions have
     been completed.'''
@@ -138,7 +143,7 @@ def makecatalogs():
         # Update the Munki Catalogs
         print("Updating catalogs....")
         # Suppress the output of makecatalogs
-        subprocess.check_call(['/usr/local/munki/makecatalogs'],
+        subprocess.check_call([makecatalogspath, munki_repo],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
     except StandardError as error:
@@ -147,4 +152,3 @@ def makecatalogs():
 
 if __name__ == '__main__':
     main()
-    makecatalogs()

--- a/munkipromotetemplate.conf
+++ b/munkipromotetemplate.conf
@@ -1,4 +1,5 @@
 [main]
+MAKECATALOGS = Path To makecatalogs Here
 REPO = Your Repo Here
 
 [critical]


### PR DESCRIPTION
I wanted to be able to easily use this on the Linux system that actually hosts my repo - updated to allow specification of path to makecatalogs, and to always specify repo path as arg to makecatalogs.